### PR TITLE
1. remove log  to stdout 2. enhance idempotency

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,13 @@ package main
 import (
 	"fmt"
 	"net"
+	"os"
 
+	"github.com/Sirupsen/logrus"
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/rancher/rancher-cni-bridge/macfinder"
 	"github.com/rancher/rancher-cni-bridge/macfinder/metadata"
 	"github.com/vishvananda/netlink"
@@ -39,4 +45,71 @@ func findMACAddressForContainer(containerID, rancherID string) (string, error) {
 	}
 
 	return macString, nil
+}
+
+func checkIfContainerInterfaceExists(args *skel.CmdArgs) bool {
+	err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		_, err := netlink.LinkByName(args.IfName)
+		if err != nil {
+			return fmt.Errorf("failed to lookup %q: %v", args.IfName, err)
+		}
+		return nil
+	})
+
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+func setInterfaceDown(args *skel.CmdArgs) error {
+	err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		link, err := netlink.LinkByName(args.IfName)
+		if err != nil {
+			return fmt.Errorf("failed to lookup %q: %v", args.IfName, err)
+		}
+		err = netlink.LinkSetDown(link)
+		if err != nil {
+			return fmt.Errorf("failed to setdown %q: %v", args.IfName, err)
+		}
+		return nil
+	})
+	return err
+
+}
+
+func configureInterface(ifName string, res *types.Result) error {
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("failed to lookup %q: %v", ifName, err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("failed to set %q UP: %v", ifName, err)
+	}
+
+	// TODO(eyakubovich): IPv6
+	addr := &netlink.Addr{IPNet: &res.IP4.IP, Label: ""}
+	if err = netlink.AddrAdd(link, addr); err != nil {
+		if err.Error() == "file exists" {
+			logrus.Infof("rancher-cni-macvlan: Interface %q already has IP address: %v, no worries", ifName, addr)
+		} else {
+			return fmt.Errorf("failed to add IP addr to %q: %v", ifName, err)
+		}
+	}
+
+	for _, r := range res.IP4.Routes {
+		gw := r.GW
+		if gw == nil {
+			gw = res.IP4.Gateway
+		}
+		if err = ip.AddRoute(&r.Dst, gw, link); err != nil {
+			// we skip over duplicate routes as we assume the first one wins
+			if !os.IsExist(err) {
+				return fmt.Errorf("failed to add route '%v via %v dev %v': %v", r.Dst, gw, ifName, err)
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
1. remove log  to stdout.
CNI driver standard output must be the json of types.Result. Use logrus.Infof instead of fmt.Fprintf.

2. enhance idempotency
network manager will retry cni add while it is failing, so the idempotency of add must be ensured.
a. use checkIfContainerInterfaceExists, only when it returns false then we call createMacvlan. checkIfContainerInterfaceExists is copied from util.go from rancher-cni-bridge.
b. when checkIfContainerInterfaceExists returns true, invoke setInterfaceDown. Otherwise when set Mac address for dev, "Device or resource busy" error will show up.
c.  use configureInterface instead of ipam.ConfigureIface. configureInterface is copied from util.go from rancher-cni-bridge, it will not return error if "file exist" error shows when adding ip addr.